### PR TITLE
Multi-Arch experiment

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -46,11 +46,19 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.7.0/rules_nodejs-5.7.0.tar.gz"],
 )
 
-http_archive(
+# http_archive(
+#     name = "rules_oci",
+#     sha256 = "176e601d21d1151efd88b6b027a24e782493c5d623d8c6211c7767f306d655c8",
+#     strip_prefix = "rules_oci-1.2.0",
+#     url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.2.0/rules_oci-v1.2.0.tar.gz",
+# )
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+git_repository(
     name = "rules_oci",
-    sha256 = "176e601d21d1151efd88b6b027a24e782493c5d623d8c6211c7767f306d655c8",
-    strip_prefix = "rules_oci-1.2.0",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.2.0/rules_oci-v1.2.0.tar.gz",
+    commit = "3a94776886bf044261d56c97246bc4c11ed76cdc",
+    remote = "https://github.com/illicitonion/rules_oci.git",
+    verbose = False,
 )
 
 http_archive(

--- a/projects/go_web/BUILD.bazel
+++ b/projects/go_web/BUILD.bazel
@@ -71,6 +71,13 @@ oci_image_index(
     ],
 )
 
+oci_tarball(
+    name = "multi_arch_tarball",
+    format = "oci",
+    image = ":multi_arch_image",
+    repo_tags = ["projects/go_web:oci_tarball_multi_arch"],
+)
+
 oci_push(
     name = "publish",
     image = ":multi_arch_image",


### PR DESCRIPTION
This is an experiment based from curiosity of https://github.com/bazel-contrib/rules_oci/pull/325.

It looks like there are some gaps but it is possible to make it work in some way..

The expected tag of the image does not work, but referencing the image ID does work as expected.

```
➜ bazel run projects/go_web:multi_arch_tarball
```

```
➜ docker images | grep projects/go_web
projects/go_web                    oci_tarball_multi_arch   d76e9c38d7ed   21 minutes ago   56.3MB
...
➜  docker run --platform linux/amd64 d76e9c38d7ed 
2023/10/06 13:58:16 running program's operating system target: linux
2023/10/06 13:58:16 running program's architecture target: amd64
2023/10/06 13:58:16 Going to listen on port: 8080
...                                                                                            
➜  docker run --platform linux/arm64 d76e9c38d7ed
2023/10/06 13:58:25 running program's operating system target: linux
2023/10/06 13:58:25 running program's architecture target: arm64
2023/10/06 13:58:25 Going to listen on port: 8080
```

You can also make it work if you re-tag the image..

```
➜  docker tag d76e9c38d7ed my-image:1     
...                                                                                                                                                                           
➜  docker run --platform linux/arm64 my-image:1 
2023/10/06 14:01:37 running program's operating system target: linux
2023/10/06 14:01:37 running program's architecture target: arm64
2023/10/06 14:01:37 Going to listen on port: 8080
...                                                                                              
➜  docker run --platform linux/amd64 my-image:1
2023/10/06 14:01:42 running program's operating system target: linux
2023/10/06 14:01:42 running program's architecture target: amd64
2023/10/06 14:01:42 Going to listen on port: 8080
```